### PR TITLE
Add G-SAE experiment setup

### DIFF
--- a/experiments/base_config.yaml
+++ b/experiments/base_config.yaml
@@ -1,0 +1,15 @@
+n_op_shards: 1
+n_replicas: 8
+n_dirs: 32768
+bs: 131072
+d_model: 768
+k: 32
+auxk: 256
+lr: 1e-4
+eps: 6.25e-10
+clip_grad: null
+auxk_coef: 0.03125
+dead_toks_threshold: 10000000
+ema_multiplier: null
+wandb_project: null
+wandb_name: null

--- a/experiments/gsae/generate_groups.py
+++ b/experiments/gsae/generate_groups.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+
+def generate_group_mapping(latent_dim: int, group_size: int) -> dict[str, int]:
+    """Generate non-overlapping groups of specified size."""
+    mapping = {}
+    for i in range(latent_dim):
+        mapping[str(i)] = i // group_size
+    return mapping
+
+
+def main(latent_dim: int = 16384, group_size: int = 8) -> None:
+    group_spec = {
+        "latent_dim": latent_dim,
+        "group_size": group_size,
+        "mapping": generate_group_mapping(latent_dim, group_size),
+    }
+    out_path = Path(__file__).parent / "group_spec.json"
+    with open(out_path, "w") as f:
+        json.dump(group_spec, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/gsae/group_spec.json
+++ b/experiments/gsae/group_spec.json
@@ -1,0 +1,5 @@
+{
+  "latent_dim": null,
+  "group_size": 8,
+  "mapping": {}
+}

--- a/experiments/gsae/gsae.yaml
+++ b/experiments/gsae/gsae.yaml
@@ -1,0 +1,13 @@
+defaults:
+  - ../base_config
+
+model:
+  group_size: 8
+  lambda_group: 0.1
+  lambda_max: 0.1
+  anneal_steps: null
+  group_penalty_type: "l1"
+
+experiment:
+  name: "gsae-pilot"
+  checkpoint_every: 50000


### PR DESCRIPTION
## Summary
- add base experiment config mirroring train.py defaults
- configure `gsae` experiment with group-sparse AE parameters
- include an initial empty group specification
- provide script to generate grouping json

## Testing
- `python -m py_compile experiments/gsae/generate_groups.py`

------
https://chatgpt.com/codex/tasks/task_e_6844f45c5ab8833095c06043770814c4